### PR TITLE
Afficher les opérations mensuelles à venir

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -21,6 +21,10 @@ $danger: $red;
 $light: $white;
 $dark: $gray-dark;
 
+.opacity-0 {
+  opacity: 0;
+}
+
 // Import de la feuille de style Bootstrap par défaut
 @import "~bootstrap/scss/bootstrap";
 

--- a/public/build/app.37ebe890.css
+++ b/public/build/app.37ebe890.css
@@ -1,4 +1,5 @@
-@charset "UTF-8";
+@charset "UTF-8";.opacity-0{opacity:0}
+
 /*!
  * Bootstrap v4.6.2 (https://getbootstrap.com/)
  * Copyright 2011-2022 The Bootstrap Authors

--- a/public/build/entrypoints.json
+++ b/public/build/entrypoints.json
@@ -7,7 +7,7 @@
         "/build/app.44e0a49f.js"
       ],
       "css": [
-        "/build/app.4749494d.css"
+        "/build/app.37ebe890.css"
       ]
     }
   }

--- a/public/build/manifest.json
+++ b/public/build/manifest.json
@@ -1,5 +1,5 @@
 {
-  "build/app.css": "/build/app.4749494d.css",
+  "build/app.css": "/build/app.37ebe890.css",
   "build/app.js": "/build/app.44e0a49f.js",
   "build/runtime.js": "/build/runtime.4a257db4.js",
   "build/754.88b0cbf0.js": "/build/754.88b0cbf0.js",

--- a/src/Controller/TransactionController.php
+++ b/src/Controller/TransactionController.php
@@ -88,7 +88,8 @@ class TransactionController extends AbstractController
         $pagination = $this->pager->paginate(
             $regroupedTransactions,
             $page,
-            100
+            100,
+            ['defaultSortFieldName' => '[date]']
         );
 
         // Récupération du solde prévu en fin de mois

--- a/src/Controller/TransactionController.php
+++ b/src/Controller/TransactionController.php
@@ -3,11 +3,14 @@
 namespace App\Controller;
 
 use App\Entity\Account;
+use App\Entity\MonthlyTransaction;
 use App\Entity\Transaction;
 use App\Form\Filter\TransactionFilterType;
 use App\Form\TransactionType;
+use App\Repository\MonthlyTransactionRepository;
 use App\Repository\TransactionRepository;
 use App\Service\BalanceUpdaterService;
+use DateTime;
 use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use Knp\Component\Pager\PaginatorInterface;
@@ -22,6 +25,7 @@ class TransactionController extends AbstractController
     public function __construct(
         private readonly EntityManagerInterface $em,
         private readonly TransactionRepository $transactionRepository,
+        private readonly MonthlyTransactionRepository $monthlyTransactionRepository,
         private readonly PaginatorInterface $pager,
         private readonly BalanceUpdaterService $balanceUpdater
     ) {
@@ -69,9 +73,20 @@ class TransactionController extends AbstractController
             ])
         ]);
 
+        $regroupedTransactions = $this->regroupTransactionsAndMonthlyTransactions(
+            $this
+                ->transactionRepository
+                ->getAllTransactionsForAccountAndMonth($account, $year, $month)
+                ->getQuery()
+                ->getResult(),
+            $this->monthlyTransactionRepository->getUpcomingMonthlyTransactionsForAccount($account, $year, $month),
+            $year,
+            $month
+        );
+
         // Pagination des opérations demandées
         $pagination = $this->pager->paginate(
-            $this->transactionRepository->getAllTransactionsForAccountAndMonth($account, $year, $month),
+            $regroupedTransactions,
             $page,
             100
         );
@@ -301,5 +316,68 @@ class TransactionController extends AbstractController
         }
 
         return $groupedTransactions;
+    }
+
+    /**
+     * Regroupe les opérations et les opérations récurrentes et les trie par jour
+     * @param array $transactionsQuery
+     * @param array $monthlyTransactionsQuery
+     * @param int $year
+     * @param string $month
+     * @return array
+     */
+    private function regroupTransactionsAndMonthlyTransactions(
+        array $transactionsQuery,
+        array $monthlyTransactionsQuery,
+        int $year,
+        string $month
+    ): array {
+        $allTransactions = [];
+
+        foreach ($transactionsQuery as $transaction) {
+            /** @var Transaction $transaction */
+            $value = $transaction->getType() === 0 ? -$transaction->getValue() : $transaction->getValue();
+
+            $allTransactions[] = [
+                'type' => Transaction::class,
+                'id' => $transaction->getId(),
+                'description' => $transaction->getDescription(),
+                'date' => $transaction->getDate(),
+                'value' => $value
+            ];
+        }
+        foreach ($monthlyTransactionsQuery as $monthlyTransaction) {
+            /** @var MonthlyTransaction $monthlyTransaction */
+            $value = $monthlyTransaction->getType() === 0 ?
+                -$monthlyTransaction->getValue() :
+                $monthlyTransaction->getValue()
+            ;
+            $dayWithLeadingZero = str_pad($monthlyTransaction->getDay(), 2, '0', STR_PAD_LEFT);
+            $date = checkdate((int) $month, $monthlyTransaction->getDay(), $year) ?
+                new DateTime("$year-$month-$dayWithLeadingZero") :
+                $this->getLastDayOfMonth($year, $month)
+            ;
+
+            $allTransactions[] = [
+                'type' => MonthlyTransaction::class,
+                'id' => $monthlyTransaction->getId(),
+                'description' => $monthlyTransaction->getDescription(),
+                'date' => $date,
+                'value' => $value
+            ];
+        }
+
+        return $allTransactions;
+    }
+
+    /**
+     * Retourne le dernier jour du mois $month $year
+     * @param int $year
+     * @param string $month
+     * @return DateTime
+     */
+    private function getLastDayOfMonth(int $year, string $month): DateTime
+    {
+        return (new DateTime("$year-$month-01"))->modify('last day of this month');
     }
 }

--- a/src/Repository/MonthlyTransactionRepository.php
+++ b/src/Repository/MonthlyTransactionRepository.php
@@ -4,6 +4,7 @@ namespace App\Repository;
 
 use App\Entity\Account;
 use App\Entity\MonthlyTransaction;
+use DateTime;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
@@ -37,6 +38,33 @@ class MonthlyTransactionRepository extends ServiceEntityRepository
             ->orderBy('mt.day', 'ASC')
             ->addOrderBy('mt.description', 'ASC')
         ;
+    }
+
+    /**
+     * Retourne les opérations mensuelles à venir pour le mois $month $year
+     * @param Account $account
+     * @param int $year
+     * @param string $month
+     * @return array
+     */
+    public function getUpcomingMonthlyTransactionsForAccount(Account $account, int $year, string $month): array
+    {
+        $monthlyTransactionsForAccount = $this
+            ->getAllMonthlyTransactionsForAccount($account)
+            ->getQuery()
+            ->getResult()
+        ;
+        $today = (new DateTime())->format('Ymd');
+
+        $upcomingMonthlyTransactions = [];
+        foreach ($monthlyTransactionsForAccount as $monthlyTransaction) {
+            $monthlyTransactionDate = $year . $month . str_pad($monthlyTransaction->getDay(), 2, '0', STR_PAD_LEFT);
+            if ($monthlyTransactionDate > $today) {
+                $upcomingMonthlyTransactions[] = $monthlyTransaction;
+            }
+        }
+
+        return $upcomingMonthlyTransactions;
     }
 
     /**

--- a/src/Service/BalanceUpdaterService.php
+++ b/src/Service/BalanceUpdaterService.php
@@ -3,6 +3,7 @@
 namespace App\Service;
 
 use App\Entity\Account;
+use App\Entity\MonthlyTransaction;
 use App\Entity\Transaction;
 use App\Repository\AccountRepository;
 use App\Repository\TransactionRepository;
@@ -148,10 +149,10 @@ class BalanceUpdaterService
 
     /**
      * Retourne la valeur d'une transaction selon son type
-     * @param Transaction $transaction
+     * @param Transaction|MonthlyTransaction $transaction
      * @return float
      */
-    private function getValueFromTransaction(Transaction $transaction): float
+    private function getValueFromTransaction(Transaction|MonthlyTransaction $transaction): float
     {
         $transaction->getType() === 0 ?
             $value = -$transaction->getValue() :

--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Twig;
+
+use App\Entity\MonthlyTransaction;
+use App\Entity\Transaction;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigTest;
+
+class AppExtension extends AbstractExtension
+{
+    public function getTests(): array
+    {
+        return [
+            new TwigTest('transaction', [$this, 'isTransaction']),
+            new TwigTest('monthlytransaction', [$this, 'isMonthlyTransaction']),
+        ];
+    }
+
+    /**
+     * Teste si l'objet $object est une instance de la classe Transaction
+     * @param $object
+     * @return bool
+     */
+    public function isTransaction($object): bool
+    {
+        return $object === Transaction::class;
+    }
+
+    /**
+     * Teste si l'objet $object est une instance de la classe MonthlyTransaction
+     * @param $object
+     * @return bool
+     */
+    public function isMonthlyTransaction($object): bool
+    {
+        return $object === MonthlyTransaction::class;
+    }
+}

--- a/templates/transaction/list.html.twig
+++ b/templates/transaction/list.html.twig
@@ -96,12 +96,12 @@
                 <thead class="thead-light">
                 <tr>
                     <th>
-                        {{ knp_pagination_sortable(pagination, 'Date', 't.date') }}
+                        {{ knp_pagination_sortable(pagination, 'Date', '[date]') }}
                     </th>
                     <th>
-                        {{ knp_pagination_sortable(pagination, 'Libellé', 't.description') }}
+                        {{ knp_pagination_sortable(pagination, 'Libellé', '[description]') }}
                     </th>
-                    <th>Valeur</th>
+                    <th>{{ knp_pagination_sortable(pagination, 'Valeur', '[value]') }}</th>
                 </tr>
                 </thead>
                 <tbody>

--- a/templates/transaction/list.html.twig
+++ b/templates/transaction/list.html.twig
@@ -106,23 +106,30 @@
                 </thead>
                 <tbody>
                 {% for transaction in pagination %}
-                    {# @var \App\Entity\Transaction transaction #}
+                    {% if transaction.type is transaction %}
+                        {% set opacity = 'opacity-0' %}
+                        {% set editPath = 'transaction_edit' %}
+                    {% else %}
+                        {% set opacity = '' %}
+                        {% set editPath = 'monthly_transaction_edit' %}
+                    {% endif %}
                     <tr>
-                        <td>{{ transaction.date | date('d/m/Y') }}</td>
                         <td>
-                            <a href="{{ path('transaction_edit', {'id': transaction.id}) }}">
+                            <i class="bi bi-calendar-week {{ opacity }}"></i> {{ transaction.date | date('d/m/Y') }}
+                        </td>
+                        <td>
+                            <a href="{{ path(editPath, {'id': transaction.id}) }}">
                                 {{ transaction.description }}
                             </a>
                         </td>
-                        {% if transaction.type == 0 %}
-                            <td class="text-danger text-nowrap">
-                                - {{ transaction.value | format_number({fraction_digit: 2}) }} €
-                            </td>
-                        {% else %}
-                            <td class="text-success text-nowrap">
-                                + {{ transaction.value | format_number({fraction_digit: 2}) }} €
-                            </td>
-                        {% endif %}
+                    {% if transaction.value < 0 %}
+                        <td class="text-danger text-nowrap">
+                            {{ transaction.value | format_number({fraction_digit: 2}) }} €
+                    {% else %}
+                        <td class="text-success text-nowrap">
+                            +{{ transaction.value | format_number({fraction_digit: 2}) }} €
+                    {% endif %}
+                        </td>
                     </tr>
                 {% endfor %}
                 </tbody>


### PR DESCRIPTION
- Affiche les opérations mensuelles à venir dans la même liste que les opérations réelles
- Les opérations mensuelles sont prises en compte dans le calcul du solde en fin de mois
- Améliore le tri sur la liste des opérations grâce aux modifications effectuées