### PR TITLE
Générer une Transaction à partir d'une opération mensuelle

### DIFF
--- a/cron.daily.sh
+++ b/cron.daily.sh
@@ -7,5 +7,8 @@ cd $ROOTDIR
 # Mise à jour du solde des comptes bancaires
 symfony console balance:update
 
+# Génération des opérations mensuelles dont le jour d'occurrence a été atteint
+symfony console transaction:monthly:generate
+
 # Nettoyage des fichiers temporaires
 rm -r ~/.symfony5/tmp/*

--- a/migrations/Version020.php
+++ b/migrations/Version020.php
@@ -28,6 +28,7 @@ final class Version020 extends AbstractMigration
                 description VARCHAR(255) NOT NULL,
                 value DOUBLE PRECISION NOT NULL,
                 type SMALLINT NOT NULL,
+                next_occurrence DATE NOT NULL,
                 INDEX IDX_EF2C6F1E9B6B5FBA (account_id), PRIMARY KEY(id)
             ) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB
         ');

--- a/src/Command/TransactionGenerateCommand.php
+++ b/src/Command/TransactionGenerateCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\MonthlyTransaction;
+use App\Entity\Transaction;
+use App\Repository\MonthlyTransactionRepository;
+use App\Service\MonthlyTransactionOccurrenceCalculatorService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'transaction:monthly:generate',
+    description: "Génère des opérations à partir d'opérations mensuelles dont le jour d'occurrence a été atteint",
+)]
+class TransactionGenerateCommand extends Command
+{
+    public function __construct(
+        private readonly MonthlyTransactionRepository $monthlyTransactionRepository,
+        private readonly EntityManagerInterface $em,
+        private readonly MonthlyTransactionOccurrenceCalculatorService $occurrenceCalculator,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        // Récupérer les opérations mensuelles dont la date d'occurrence ≤ aujourd'hui
+        $reachedMonthlyTransactions = $this
+            ->monthlyTransactionRepository
+            ->getMonthlyTransactionsWithOccurrenceReached()
+            ->getQuery()
+            ->getResult()
+        ;
+
+        foreach ($reachedMonthlyTransactions as $monthlyTransaction) {
+            // Créer une opération à partir de cette opération mensuelle
+            /** @var MonthlyTransaction $monthlyTransaction */
+            $transaction = new Transaction();
+            $transaction
+                ->setAccount($monthlyTransaction->getAccount())
+                ->setDate($monthlyTransaction->getNextOccurrence())
+                ->setType($monthlyTransaction->getType())
+                ->setValue($monthlyTransaction->getValue())
+                ->setDescription($monthlyTransaction->getDescription())
+            ;
+            $this->em->persist($transaction);
+
+            // Calculer la prochaine occurrence de l'opération mensuelle
+            $monthlyTransaction->setNextOccurrence($this
+                ->occurrenceCalculator
+                ->calculateNextMonthlyTransactionOccurrence($monthlyTransaction));
+        }
+
+        // Mettre à jour la base de données
+        $this->em->flush();
+        return Command::SUCCESS;
+    }
+}

--- a/src/Entity/MonthlyTransaction.php
+++ b/src/Entity/MonthlyTransaction.php
@@ -35,6 +35,9 @@ class MonthlyTransaction
     #[ORM\Column(type: Types::SMALLINT)]
     private ?int $type = null;
 
+    #[ORM\Column(type: Types::DATE_MUTABLE)]
+    private ?\DateTimeInterface $nextOccurrence = null;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -96,6 +99,18 @@ class MonthlyTransaction
     public function setType(int $type): static
     {
         $this->type = $type;
+
+        return $this;
+    }
+
+    public function getNextOccurrence(): ?\DateTimeInterface
+    {
+        return $this->nextOccurrence;
+    }
+
+    public function setNextOccurrence(\DateTimeInterface $nextOccurrence): static
+    {
+        $this->nextOccurrence = $nextOccurrence;
 
         return $this;
     }

--- a/src/Repository/MonthlyTransactionRepository.php
+++ b/src/Repository/MonthlyTransactionRepository.php
@@ -68,6 +68,21 @@ class MonthlyTransactionRepository extends ServiceEntityRepository
     }
 
     /**
+     * Retourne les opérations mensuelles dont la date de prochaine occurrence a été atteinte
+     * @return QueryBuilder
+     */
+    public function getMonthlyTransactionsWithOccurrenceReached(): QueryBuilder
+    {
+        $now = new DateTime();
+
+        return $this
+            ->createQueryBuilder('mt')
+            ->where('mt.nextOccurrence <= :now')
+            ->setParameter('now', $now)
+        ;
+    }
+
+    /**
      * Retourne les opérations mensuelles filtrées selon la requête $filterQuery pour le compte bancaire $account
      * @param Account $account
      * @param array $filterQuery

--- a/src/Service/MonthlyTransactionOccurrenceCalculatorService.php
+++ b/src/Service/MonthlyTransactionOccurrenceCalculatorService.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Service;
+
+/**
+ * Service permettant de calculer la prochaine occurrence d'une opération mensuelle
+ */
+class MonthlyTransactionOccurrenceCalculatorService
+{
+}

--- a/src/Service/MonthlyTransactionOccurrenceCalculatorService.php
+++ b/src/Service/MonthlyTransactionOccurrenceCalculatorService.php
@@ -2,9 +2,62 @@
 
 namespace App\Service;
 
+use App\Entity\MonthlyTransaction;
+use DateTime;
+
 /**
  * Service permettant de calculer la prochaine occurrence d'une opération mensuelle
  */
 class MonthlyTransactionOccurrenceCalculatorService
 {
+    /**
+     * Calcule l'occurrence de l'opération mensuelle $monthlyTransaction sur le mois $month $year
+     * @param MonthlyTransaction $monthlyTransaction
+     * @param int $year
+     * @param string $month
+     * @return DateTime
+     */
+    public function calculateMonthlyTransactionOccurrence(
+        MonthlyTransaction $monthlyTransaction,
+        int $year,
+        string $month
+    ): DateTime {
+        $dayWithLeadingZero = str_pad($monthlyTransaction->getDay(), 2, '0', STR_PAD_LEFT);
+
+        return checkdate((int) $month, $monthlyTransaction->getDay(), $year) ?
+            new DateTime("$year-$month-$dayWithLeadingZero") :
+            $this->getLastDayOfMonth($year, $month)
+        ;
+    }
+
+    /**
+     * Calcule la prochaine occurrence de l'opération mensuelle $monthlyTransaction
+     * @param MonthlyTransaction $monthlyTransaction
+     * @return DateTime
+     */
+    public function calculateNextMonthlyTransactionOccurrence(MonthlyTransaction $monthlyTransaction): DateTime
+    {
+        $nextOccurrence = new DateTime();
+
+        if ($monthlyTransaction->getDay() <= $nextOccurrence->format('j')) {
+            $nextOccurrence->modify('next month');
+        }
+
+        return $this->calculateMonthlyTransactionOccurrence(
+            $monthlyTransaction,
+            $nextOccurrence->format('Y'),
+            $nextOccurrence->format('m')
+        );
+    }
+
+    /**
+     * Retourne le dernier jour du mois $month $year
+     * @param int $year
+     * @param string $month
+     * @return DateTime
+     */
+    private function getLastDayOfMonth(int $year, string $month): DateTime
+    {
+        return (new DateTime("$year-$month-01"))->modify('last day of this month');
+    }
 }

--- a/templates/monthly_transaction/list.html.twig
+++ b/templates/monthly_transaction/list.html.twig
@@ -31,12 +31,13 @@
             <thead class="thead-light">
             <tr>
                 <th>
-                    {{ knp_pagination_sortable(pagination, "Jour de l'occurrence", 'mt.day') }}
+                    {{ knp_pagination_sortable(pagination, "Jour de l'occur.", 'mt.day') }}
                 </th>
                 <th>
                     {{ knp_pagination_sortable(pagination, 'Libellé', 'mt.description') }}
                 </th>
                 <th>Valeur</th>
+                <th>{{ knp_pagination_sortable(pagination, 'Prochaine occur.', 'mt.nextOccurrence') }}</th>
             </tr>
             </thead>
             <tbody>
@@ -58,6 +59,7 @@
                             + {{ monthlyTransaction.value | format_number({fraction_digit: 2}) }} €
                         </td>
                     {% endif %}
+                    <td>{{ monthlyTransaction.nextOccurrence | date('d/m/Y') }}</td>
                 </tr>
             {% endfor %}
             </tbody>


### PR DESCRIPTION
https://github.com/Koretech10/korexpenses/issues/25

- Ajoute le champ nextOccurrence à MonthlyTransaction
- Permet de calculer la prochain occurrence d'une MonthlyTransaction
- Génère une Transaction quand l'occurrence de la MonthlyTransaction est atteinte